### PR TITLE
Improve build times

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -16,7 +16,7 @@ DEPFLAGS = -MT $$@ -MMD -MP -MF $(DEPDIR)/$$*.Td
 MAKEDEPFOLDER = -$(VV)mkdir -p $(DEPDIR)/$$(dir $$(patsubst $(BINDIR)/%, %, $(ROOT)/$$@))
 RENAMEDEPENDENCYFILE = -$(VV)mv -f $(DEPDIR)/$$*.Td $$(patsubst $(SRCDIR)/%, $(DEPDIR)/%.d, $(ROOT)/$$<) && touch $$@
 
-LIBRARIES+=$(wildcard $(FWDIR)/*.a)
+LIBRARIES+=$(FWDIR)/libc.a $(FWDIR)/libm.a $(FWDIR)/libpros.a
 # Cannot include newlib and libc because not all of the req'd stubs are implemented
 EXCLUDE_COLD_LIBRARIES+=$(FWDIR)/libc.a $(FWDIR)/libm.a
 COLD_LIBRARIES=$(filter-out $(EXCLUDE_COLD_LIBRARIES), $(LIBRARIES))
@@ -147,7 +147,7 @@ GETALLOBJ=$(sort $(call ASMOBJ,$1) $(call COBJ,$1) $(call CXXOBJ,$1))
 
 ARCHIVE_TEXT_LIST=$(subst $(SPACE),$(COMMA),$(notdir $(basename $(LIBRARIES))))
 
-LDTIMEOBJ:=$(BINDIR)/_pros_ld_timestamp.o
+#LDTIMEOBJ:=$(BINDIR)/_pros_ld_timestamp.o
 
 MONOLITH_BIN:=$(BINDIR)/monolith.bin
 MONOLITH_ELF:=$(basename $(MONOLITH_BIN)).elf
@@ -217,7 +217,7 @@ $(MONOLITH_BIN): $(MONOLITH_ELF) $(BINDIR)
 
 $(MONOLITH_ELF): $(ELF_DEPS) $(LIBRARIES)
 	$(call _pros_ld_timestamp)
-	$(call test_output_2,Linking project with $(ARCHIVE_TEXT_LIST) ,$(LD) $(LDFLAGS) $(ELF_DEPS) $(LDTIMEOBJ) $(call wlprefix,-T$(FWDIR)/v5.ld $(LNK_FLAGS)) -o $@,$(OK_STRING))
+	$(call test_output_2,Linking project with $(ARCHIVE_TEXT_LIST) ,$(LD) $(LDFLAGS) $(ELF_DEPS) $(call wlprefix,-T$(FWDIR)/v5.ld $(LNK_FLAGS)) -o $@,$(OK_STRING))
 	@echo Section sizes:
 	-$(VV)$(SIZETOOL) $(SIZEFLAGS) $@ $(SIZES_SED) $(SIZES_NUMFMT)
 
@@ -235,8 +235,7 @@ $(HOT_BIN): $(HOT_ELF) $(COLD_BIN)
 	$(call test_output_2,Creating $@ for $(DEVICE) ,$(OBJCOPY) $< -O binary $@,$(DONE_STRING))
 
 $(HOT_ELF): $(COLD_ELF) $(ELF_DEPS)
-	$(call _pros_ld_timestamp)
-	$(call test_output_2,Linking hot project with $(COLD_ELF) and $(ARCHIVE_TEXT_LIST) ,$(LD) -nostartfiles $(LDFLAGS) $(call wlprefix,-R $<) $(filter-out $<,$^) $(LDTIMEOBJ) $(LIBRARIES) $(call wlprefix,-T$(FWDIR)/v5-hot.ld $(LNK_FLAGS) -o $@),$(OK_STRING))
+	$(call test_output_2,Linking hot project with $(COLD_ELF) and $(ARCHIVE_TEXT_LIST) ,$(LD) -nostartfiles $(LDFLAGS) $(call wlprefix,-R $<) $(filter-out $<,$^) $(LIBRARIES) $(call wlprefix,-T$(FWDIR)/v5-hot.ld $(LNK_FLAGS) -o $@),$(OK_STRING))
 	@printf "%s\n" "Section sizes:"
 	-$(VV)$(SIZETOOL) $(SIZEFLAGS) $@ $(SIZES_SED) $(SIZES_NUMFMT)
 
@@ -272,7 +271,7 @@ $(VV)mkdir -p $(dir $(LDTIMEOBJ))
 @# Pipe a line of code defining _PROS_COMPILE_TOOLSTAMP and _PROS_COMPILE_DIRECTORY into GCC,
 @# which allows compilation from stdin. We define _PROS_COMPILE_DIRECTORY using a command line-defined macro
 @# which is the pwd | tail bit, which will truncate the path to the last 23 characters
-$(call test_output_2,Adding timestamp ,echo 'char const * const _PROS_COMPILE_TIMESTAMP = __DATE__ " " __TIME__; char const * const _PROS_COMPILE_DIRECTORY = "$(shell pwd | tail -c 23)";' | $(CC) -c -x c $(CFLAGS) $(EXTRA_CFLAGS) -o $(LDTIMEOBJ) -,$(OK_STRING))
+$(call test_output_2,Adding timestamp ,echo 'char const * const _PROS_COMPILE_TIMESTAMP = __DATE__ " " __TIME__; char const * const _PROS_COMPILE_DIRECTORY = "$(shell pwd | tail -c 23)";' | $(CC) -c -x c $(CFLAGS) $(EXTRA_CFLAGS) -o $(LDTIMEOBJ2) -,$(OK_STRING))
 endef
 
 # these rules are for build-compile-commands, which just print out sysroot information

--- a/common.mk
+++ b/common.mk
@@ -217,7 +217,7 @@ $(MONOLITH_BIN): $(MONOLITH_ELF) $(BINDIR)
 
 $(MONOLITH_ELF): $(ELF_DEPS) $(LIBRARIES)
 	$(call _pros_ld_timestamp)
-	$(call test_output_2,Linking project with $(ARCHIVE_TEXT_LIST) ,$(LD) $(LDFLAGS) $(ELF_DEPS) $(call wlprefix,-T$(FWDIR)/v5.ld $(LNK_FLAGS)) -o $@,$(OK_STRING))
+	$(call test_output_2,Linking project with $(ARCHIVE_TEXT_LIST) ,$(LD) $(LDFLAGS) $(ELF_DEPS) $(LDTIMEOBJ) $(call wlprefix,-T$(FWDIR)/v5.ld $(LNK_FLAGS)) -o $@,$(OK_STRING))
 	@echo Section sizes:
 	-$(VV)$(SIZETOOL) $(SIZEFLAGS) $@ $(SIZES_SED) $(SIZES_NUMFMT)
 
@@ -235,7 +235,8 @@ $(HOT_BIN): $(HOT_ELF) $(COLD_BIN)
 	$(call test_output_2,Creating $@ for $(DEVICE) ,$(OBJCOPY) $< -O binary $@,$(DONE_STRING))
 
 $(HOT_ELF): $(COLD_ELF) $(ELF_DEPS)
-	$(call test_output_2,Linking hot project with $(COLD_ELF) and $(ARCHIVE_TEXT_LIST) ,$(LD) -nostartfiles $(LDFLAGS) $(call wlprefix,-R $<) $(filter-out $<,$^) $(LIBRARIES) $(call wlprefix,-T$(FWDIR)/v5-hot.ld $(LNK_FLAGS) -o $@),$(OK_STRING))
+#	$(call _pros_ld_timestamp)
+	$(call test_output_2,Linking hot project with $(COLD_ELF) and $(ARCHIVE_TEXT_LIST) ,$(LD) -nostartfiles $(LDFLAGS) $(call wlprefix,-R $<) $(filter-out $<,$^) $(LDTIMEOBJ) $(LIBRARIES) $(call wlprefix,-T$(FWDIR)/v5-hot.ld $(LNK_FLAGS) -o $@),$(OK_STRING))
 	@printf "%s\n" "Section sizes:"
 	-$(VV)$(SIZETOOL) $(SIZEFLAGS) $@ $(SIZES_SED) $(SIZES_NUMFMT)
 
@@ -271,7 +272,7 @@ $(VV)mkdir -p $(dir $(LDTIMEOBJ))
 @# Pipe a line of code defining _PROS_COMPILE_TOOLSTAMP and _PROS_COMPILE_DIRECTORY into GCC,
 @# which allows compilation from stdin. We define _PROS_COMPILE_DIRECTORY using a command line-defined macro
 @# which is the pwd | tail bit, which will truncate the path to the last 23 characters
-$(call test_output_2,Adding timestamp ,echo 'char const * const _PROS_COMPILE_TIMESTAMP = __DATE__ " " __TIME__; char const * const _PROS_COMPILE_DIRECTORY = "$(shell pwd | tail -c 23)";' | $(CC) -c -x c $(CFLAGS) $(EXTRA_CFLAGS) -o $(LDTIMEOBJ2) -,$(OK_STRING))
+$(call test_output_2,Adding timestamp ,echo 'char const * const _PROS_COMPILE_TIMESTAMP = __DATE__ " " __TIME__; char const * const _PROS_COMPILE_DIRECTORY = "$(shell pwd | tail -c 23)";' | $(CC) -c -x c $(CFLAGS) $(EXTRA_CFLAGS) -o $(LDTIMEOBJ) -,$(OK_STRING))
 endef
 
 # these rules are for build-compile-commands, which just print out sysroot information

--- a/common.mk
+++ b/common.mk
@@ -216,7 +216,7 @@ $(MONOLITH_BIN): $(MONOLITH_ELF) $(BINDIR)
 	$(call test_output_2,Creating $@ for $(DEVICE) ,$(OBJCOPY) $< -O binary -R .hot_init $@,$(DONE_STRING))
 
 $(MONOLITH_ELF): $(ELF_DEPS) $(LIBRARIES)
-	$(call _pros_ld_timestamp)
+#	$(call _pros_ld_timestamp)
 	$(call test_output_2,Linking project with $(ARCHIVE_TEXT_LIST) ,$(LD) $(LDFLAGS) $(ELF_DEPS) $(LDTIMEOBJ) $(call wlprefix,-T$(FWDIR)/v5.ld $(LNK_FLAGS)) -o $@,$(OK_STRING))
 	@echo Section sizes:
 	-$(VV)$(SIZETOOL) $(SIZEFLAGS) $@ $(SIZES_SED) $(SIZES_NUMFMT)

--- a/include/api.h
+++ b/include/api.h
@@ -16,28 +16,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#ifndef _PROS_API_H_
-#define _PROS_API_H_
+#pragma once
 
-#ifdef __cplusplus
-#include <cerrno>
-#include <cmath>
-#include <cstdbool>
-#include <cstddef>
-#include <cstdint>
-#include <cstdio>
-#include <cstdlib>
-#include <iostream>
-#else /* (not) __cplusplus */
-#include <errno.h>
-#include <math.h>
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
-#endif /* __cplusplus */
+// #include <cerrno>
+//#include <cmath>
+//#include <cstdbool>
+//#include <cstddef>
+//#include <cstdint>
+//#include <cstdio>
+//#include <cstdlib>
+//#include <iostream>
 
 #define PROS_VERSION_MAJOR 3
 #define PROS_VERSION_MINOR 5
@@ -47,34 +35,30 @@
 #define PROS_ERR (INT32_MAX)
 #define PROS_ERR_F (INFINITY)
 
-#include "pros/adi.h"
-#include "pros/colors.h"
-#include "pros/distance.h"
-#include "pros/ext_adi.h"
-#include "pros/gps.h"
-#include "pros/imu.h"
-#include "pros/llemu.h"
-#include "pros/misc.h"
-#include "pros/motors.h"
-#include "pros/optical.h"
-#include "pros/rtos.h"
-#include "pros/rotation.h"
-#include "pros/screen.h"
-#include "pros/vision.h"
+//#include "pros/adi.h"
+//#include "pros/colors.h"
+//#include "pros/distance.h"
+//#include "pros/ext_adi.h"
+//#include "pros/gps.h"
+//#include "pros/imu.h"
+//#include "pros/llemu.h"
+//#include "pros/misc.h"
+//#include "pros/motors.h"
+//#include "pros/optical.h"
+//#include "pros/rtos.h"
+//#include "pros/rotation.h"
+//#include "pros/screen.h"
+//#include "pros/vision.h"
 
-#ifdef __cplusplus
-#include "pros/adi.hpp"
-#include "pros/distance.hpp"
-#include "pros/gps.hpp"
-#include "pros/imu.hpp"
-#include "pros/llemu.hpp"
+//#include "pros/adi.hpp"
+//#include "pros/distance.hpp"
+//#include "pros/gps.hpp"
+//#include "pros/imu.hpp"
+// #include "pros/llemu.hpp"
 #include "pros/misc.hpp"
 #include "pros/motors.hpp"
-#include "pros/optical.hpp"
-#include "pros/rotation.hpp"
+//#include "pros/optical.hpp"
+//#include "pros/rotation.hpp"
 #include "pros/rtos.hpp"
-#include "pros/screen.hpp"
-#include "pros/vision.hpp"
-#endif
-
-#endif  // _PROS_API_H_
+//#include "pros/screen.hpp"
+//#include "pros/vision.hpp"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,12 +1,23 @@
 #include "main.h"
 
+/*
+ * Presence of these two variables here replaces _pros_ld_timestamp step in common.mk.
+ * THis way we get equivalent behavior without extra .c file to compile, and this faster build.
+ * Pros uses value from _PROS_COMPILE_TIMESTAMP to show time on cortex / remote (I think).
+ * I'm not sure how _PROS_COMPILE_DIRECTORY is used, but it's not full path (only first 23 characters)
+ * and not clear if it matters at all (likely also shows somewhere on cortex, which has no usage).
+ * If both of these variables are not present, final binary output becomes larger. Not sure why.
+ */
+extern "C" char const * const _PROS_COMPILE_TIMESTAMP = __DATE__ " " __TIME__;
+extern "C" char const * const _PROS_COMPILE_DIRECTORY = "";
+
 /**
  * A callback function for LLEMU's center button.
  *
  * When this callback is fired, it will toggle line 2 of the LCD text between
  * "I was pressed!" and nothing.
  */
-
+/*
 void on_center_button()
 {
 	static bool pressed = false;
@@ -20,7 +31,7 @@ void on_center_button()
 		pros::lcd::clear_line(2);
 	}
 }
-
+*/
 /**
  * Runs initialization code. This occurs as soon as the program is started.
  *
@@ -29,10 +40,12 @@ void on_center_button()
  */
 void initialize()
 {
+	/*
 	pros::lcd::initialize();
 	pros::lcd::set_text(1, "Hello PROS User!");
 
 	pros::lcd::register_btn1_cb(on_center_button);
+	*/
 }
 
 /**
@@ -146,10 +159,11 @@ void opcontrol()
 
 	while (true)
 	{
-
+		/*
 		pros::lcd::print(0, "%d %d %d", (pros::lcd::read_buttons() & LCD_BTN_LEFT) >> 2,
 						 (pros::lcd::read_buttons() & LCD_BTN_CENTER) >> 1,
 						 (pros::lcd::read_buttons() & LCD_BTN_RIGHT) >> 0);
+		*/
 		int leftSpeed = 0;
 		int rightSpeed = 0;
 		int analogY = master.get_analog(ANALOG_LEFT_Y);


### PR DESCRIPTION
This change includes the following changes:
1. Removes **okapi lib** from list of libs included in linking. Instead of linking all libs in firmware folder, list specific libs (libc.a, libm.a, libpros.a) and by doing so exclude humongous okapilib.a (28Mb!). It's not used right now in the project, so no need to pay the cost of linker to consider it and not use anything from it.
2. Currently, there are two files compiled in the project - main.cpp, and one created on the fly (let's call it **_pros_ld_timestamp.c**, but there is no file on disk, content is created on the fly and piped to compiler). These steps are synchronous, i.e., go one after another, so it slows down build (you can see it in console - it prints "Adding timestamp"). If you look at common.mk, the only thing in that second file - two \_PROS_COMPILE_* variables that record current date-time and path to project. We can do same think in main.cpp, and thus eliminate that extra step and speed up the build process.
3. There are a ton of **headers (.h)** included that compiler needs to parse. Each header in api.h includes other headers, so number is really large - you can see it by examining .d\main.cpp.d file - after this change it shrunk like 10x, maybe even 50x.
   - biggest offender is LCD includes, so for now I commented out all LCD code as realistically we do not use it yet.

Note that either of these steps could be undone in the future if we have a need in a feature that is turned off. I.e., if we start using okapi lib, or LCD, we will undo appropriate step, of figure out how to enable it in more efficient way. The purpose of this change is to optimize process given what we use today.