### PR TITLE
Consistent naming

### DIFF
--- a/include/main.h
+++ b/include/main.h
@@ -70,12 +70,12 @@ void opcontrol(void);
 }
 #endif
 
-#define LeftMotor1 9
-#define RightMotor1 2
-#define LeftMotor2 11
-#define RightMotor2 20
-#define LeftMiddle 1
-#define RightMiddle 5
+#define LeftFrontPort 9
+#define RightFrontPort 2
+#define LeftBackPort 11
+#define RightBackPort 20
+#define LeftMiddlePort 1
+#define RightMiddlePort 5
 #define frontLift 7
 #define backLift 6
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,13 +56,15 @@ void competition_initialize() {}
 class Autonomous
 {
 	//setting all the ports and motors
-	pros::Motor left_back{LeftMotor2};
-	pros::Motor right_back{RightMotor2, true};
-	pros::Motor left_front{LeftMotor1};
-	pros::Motor right_front{RightMotor1, true};
-	pros::Motor middle_right{RightMiddle};
-	pros::Motor middle_left{LeftMiddle, true};
+	pros::Motor left_back{LeftBackPort};
+	pros::Motor left_middle{LeftMiddlePort, true};
+	pros::Motor left_front{LeftFrontPort};
+	pros::Motor right_back{RightBackPort, true};
+	pros::Motor right_middle{RightMiddlePort};
+	pros::Motor right_front{RightFrontPort, true};
+
 	pros::Controller master{CONTROLLER_MASTER};
+
 	pros::Motor lift_Front{frontLift, MOTOR_GEARSET_36, true}; // Pick correct gearset (36 is red)
 	pros::Motor lift_Back{backLift, MOTOR_GEARSET_36};
 
@@ -72,8 +74,8 @@ class Autonomous
 		right_front.move_relative(ticks, speed);
 		left_back.move_relative(ticks, speed);
 		right_back.move_relative(ticks, speed);
-		middle_left.move_relative(ticks, speed);
-		middle_right.move_relative(ticks, speed);
+		left_middle.move_relative(ticks, speed);
+		right_middle.move_relative(ticks, speed);
 	}
 
 public:
@@ -130,16 +132,21 @@ void autonomous()
 void opcontrol()
 {
 	pros::Controller master(CONTROLLER_MASTER);
-	pros::Motor left_back(LeftMotor2);
-	pros::Motor right_back(RightMotor2, true);
-	pros::Motor left_front(LeftMotor1);
-	pros::Motor right_front(RightMotor1, true);
-	pros::Motor middle_right(RightMiddle);
-	pros::Motor middle_left(LeftMiddle, true);
+
+	pros::Motor left_back(LeftBackPort);
+	pros::Motor left_middle(LeftMiddlePort, true);
+	pros::Motor left_front(LeftFrontPort);
+
+	pros::Motor right_back(RightBackPort, true);
+	pros::Motor right_middle(RightMiddlePort);
+	pros::Motor right_front(RightFrontPort, true);
+
 	pros::Motor lift_Front(frontLift, MOTOR_GEARSET_36, true); // Pick correct gearset (36 is red)
 	pros::Motor lift_Back(backLift, MOTOR_GEARSET_36);
+
 	lift_Front.set_brake_mode(pros::E_MOTOR_BRAKE_HOLD);
 	lift_Back.set_brake_mode(pros::E_MOTOR_BRAKE_HOLD);
+
 	bool conveyor_up = false;
 	bool conveyor_down = false;
 	int dead_Zone = 10; //the deadzone for the joysticks
@@ -186,38 +193,39 @@ void opcontrol()
 			rightSpeed = analogY;
 		}
 
-	if (master.get_digital(DIGITAL_R1))
-	{
-		lift_Front.move_velocity(90); //pick a velocity for the lifting
-	}
-	else if (master.get_digital(DIGITAL_R2))
-	{
-		lift_Front.move_velocity(-90);
-	}
-	else
-	{
-		lift_Front.move_velocity(0);
-	}
+		if (master.get_digital(DIGITAL_R1))
+		{
+			lift_Front.move_velocity(90); //pick a velocity for the lifting
+		}
+		else if (master.get_digital(DIGITAL_R2))
+		{
+			lift_Front.move_velocity(-90);
+		}
+		else
+		{
+			lift_Front.move_velocity(0);
+		}
 
-	if (master.get_digital(DIGITAL_L1))
-	{
-		lift_Back.move_velocity(90); //pick a velocity for the lifting
-	}
-	else if (master.get_digital(DIGITAL_L2))
-	{
-		lift_Back.move_velocity(-90);
-	}
-	else
-	{
-		lift_Back.move_velocity(0);
-	}
+		if (master.get_digital(DIGITAL_L1))
+		{
+			lift_Back.move_velocity(90); //pick a velocity for the lifting
+		}
+		else if (master.get_digital(DIGITAL_L2))
+		{
+			lift_Back.move_velocity(-90);
+		}
+		else
+		{
+			lift_Back.move_velocity(0);
+		}
 
-	left_back = leftSpeed * 1.574;
-	right_back = rightSpeed * 1.574;
-	left_front.move(leftSpeed * 1.574);
-	right_front.move(rightSpeed * 1.574);
-	middle_left.move(leftSpeed * 1.574);
-	middle_right.move(rightSpeed * 1.574);
-	pros::delay(10);
-}
+		left_back.move(leftSpeed * 1.574);
+		right_back.move(rightSpeed * 1.574);
+		left_front.move(leftSpeed * 1.574);
+		right_front.move(rightSpeed * 1.574);
+		left_middle.move(leftSpeed * 1.574);
+		right_middle.move(rightSpeed * 1.574);
+
+		pros::delay(10);
+	}
 }


### PR DESCRIPTION
This PR does not change any of the existing behaviors.
It only
1. Gives things consistent naming
   - For example, all constants that are port constants will have "Port" word at the end and will be formatted same way - "[Left|Right] [Front|Back|Middle] Port" (for motor ports). Similar, for names of motor objects, and usage of move() method instead of operator =.
2. Adds consistent indentation
3. Adds some empty lines for readability